### PR TITLE
Refactor order creation to parse JSON and generate signed URLs

### DIFF
--- a/functions/create-order.js
+++ b/functions/create-order.js
@@ -1,6 +1,5 @@
 // functions/create-order.js
 const { createClient } = require("@supabase/supabase-js");
-const Busboy = require("busboy");
 const { Resend } = require("resend");
 
 // --- Env ---
@@ -12,64 +11,26 @@ const ORDERS_EMAIL_FROM = process.env.ORDERS_EMAIL_FROM;         // e.g., orders
 
 const resend = new Resend(RESEND_API_KEY);
 
-// Parse multipart/form-data from Netlify event
-function parseMultipart(event) {
-  return new Promise((resolve, reject) => {
-    const headers = event.headers || {};
-    const contentType = headers["content-type"] || headers["Content-Type"];
-    if (!contentType) return reject(new Error("Missing content-type"));
-    const bb = Busboy({ headers: { "content-type": contentType } });
-
-    const fields = {};
-    const files = [];
-
-    bb.on("file", (fieldname, file, info) => {
-      const { filename, mimeType } = info;
-      const chunks = [];
-      file.on("data", (d) => chunks.push(d));
-      file.on("end", () => {
-        files.push({
-          fieldname,
-          filename,
-          contentType: mimeType || "application/octet-stream",
-          data: Buffer.concat(chunks),
-        });
-      });
-    });
-
-    bb.on("field", (name, val) => (fields[name] = val));
-    bb.on("error", reject);
-    bb.on("finish", () => resolve({ fields, files }));
-
-    const body = event.isBase64Encoded
-      ? Buffer.from(event.body || "", "base64")
-      : Buffer.from(event.body || "", "utf8");
-
-    bb.end(body);
-  });
-}
-
-const sanitize = (s) => String(s || "").replace(/[^a-z0-9._-]+/gi, "-");
-
 exports.handler = async (event) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
 
   try {
-    // 1) Parse form
-    const { fields, files } = await parseMultipart(event);
+    if (!event.body) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Missing body" }) };
+    }
 
-    // meta.json can come as a field or a file
-    let meta;
-    const metaFile = files.find(
-      (f) => f.fieldname === "meta" || (f.filename || "").toLowerCase() === "meta.json"
-    );
-    if (metaFile) {
-      meta = JSON.parse(metaFile.data.toString("utf8"));
-    } else if (fields.meta) {
-      meta = JSON.parse(fields.meta);
-    } else {
+    let parsed;
+    try {
+      parsed = JSON.parse(event.body);
+    } catch (e) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Malformed JSON" }) };
+    }
+
+    const { meta, uploadedPaths = [] } = parsed || {};
+
+    if (!meta) {
       return { statusCode: 400, body: JSON.stringify({ error: "Missing meta" }) };
     }
 
@@ -78,35 +39,16 @@ exports.handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: "Missing orderNo in meta" }) };
     }
 
-    // 2) Upload files to Supabase Storage
+    // 2) Create signed URLs (valid 7 days) for pre-uploaded files
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
-
     const bucket = "orders"; // must exist (private)
-    const uploadedKeys = [];
 
-    for (const f of files) {
-      if (f === metaFile) continue;         // skip meta.json
-      if (f.fieldname !== "files") continue; // only artwork files
-
-      const key = `orders/${sanitize(orderNo)}/${sanitize(f.filename)}`;
-      const { error: upErr } = await supabase
-        .storage
-        .from(bucket)
-        .upload(key, f.data, { contentType: f.contentType, upsert: true });
-
-      if (upErr) {
-        return { statusCode: 500, body: JSON.stringify({ error: "Upload failed", detail: upErr.message }) };
-      }
-      uploadedKeys.push(key);
-    }
-
-    // 3) Create signed URLs (valid 7 days)
     let fileLinks = [];
-    if (uploadedKeys.length) {
+    if (uploadedPaths.length) {
       const { data, error } = await supabase
         .storage
         .from(bucket)
-        .createSignedUrls(uploadedKeys, 60 * 60 * 24 * 7);
+        .createSignedUrls(uploadedPaths, 60 * 60 * 24 * 7);
 
       if (error) {
         return { statusCode: 500, body: JSON.stringify({ error: "Signed URL error", detail: error.message }) };
@@ -174,7 +116,6 @@ ${linksText}
       body: JSON.stringify({
         ok: true,
         orderNo,
-        uploaded: uploadedKeys.length,
         files: fileLinks,
       }),
     };


### PR DESCRIPTION
## Summary
- Replace multipart parsing with direct JSON parsing for `{ meta, uploadedPaths }`
- Remove server-side uploads and generate signed URLs for pre-uploaded files
- Handle malformed JSON and send order emails with signed links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bde4f5e338832683cd2d4385e0420e