### PR TITLE
Organize uploads by product

### DIFF
--- a/functions/sign-upload.js
+++ b/functions/sign-upload.js
@@ -14,14 +14,14 @@ exports.handler = async (event) => {
       return { statusCode: 405, body: "Method Not Allowed" };
     }
 
-    const { orderNo, filename } = JSON.parse(event.body || "{}");
-    if (!orderNo || !filename) {
-      return { statusCode: 400, body: JSON.stringify({ error: "orderNo and filename required" }) };
+    const { orderNo, product, filename } = JSON.parse(event.body || "{}");
+    if (!orderNo || !product || !filename) {
+      return { statusCode: 400, body: JSON.stringify({ error: "orderNo, product, and filename required" }) };
     }
 
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
-    const objectPath = `orders/${sanitize(orderNo)}/${sanitize(filename)}`;
+    const objectPath = `orders/${sanitize(orderNo)}/${sanitize(product)}/${sanitize(filename)}`;
     const { data, error } = await supabase
       .storage
       .from("orders")

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 // === DIRECT-TO-SUPABASE UPLOAD HELPERS (paste once, above your component) ===
-async function getSignedUpload(orderNo, filename) {
+async function getSignedUpload(orderNo, product, filename) {
   const r = await fetch("/.netlify/functions/sign-upload", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ orderNo, filename }),
+    body: JSON.stringify({ orderNo, product, filename }),
   });
   const json = await r.json();
   if (!r.ok || json.error) {
@@ -557,7 +557,7 @@ export default function App() {
             throw new Error(`"${file.name}" exceeds ${MAX_MB}MB limit.`);
           }
 
-          const { signedUrl, path } = await getSignedUpload(currentOrderNo, file.name);
+          const { signedUrl, path } = await getSignedUpload(currentOrderNo, it.product, file.name);
           await uploadFileToSignedUrl(signedUrl, file);
           uploadedPaths.push(path); // bucket-relative path like "LIV-YYYYMMDD-ABCD/filename.pdf"
         }


### PR DESCRIPTION
## Summary
- Build signed upload URLs using order and product folders
- Send product info from UI and upload each item's files to its product subfolder
- Map products to files in legacy multipart uploads for correct storage paths

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be559472688326ad665b0ff655fb7b